### PR TITLE
test using version numbers on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
since Julia 0.4 is supported according to REQUIRE

would need to enable this at https://travis-ci.org/farr/Ensemble.jl
